### PR TITLE
add data import option to overwrite show_week_numbers

### DIFF
--- a/neatocal.js
+++ b/neatocal.js
@@ -984,6 +984,8 @@ function neatocal_override_param(param, data) {
     "moon_phase_position",
     "moon_phase_display",
 
+    "show_week_numbers",
+
     "cell_height",
     "highlight_color",
     "today_highlight_color",


### PR DESCRIPTION
with this little change it is possible to use the param in json import:

`{
  "param": {
    "show_week_numbers": true
  }
}
`